### PR TITLE
Add clearer logging around idam calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+#OS Stuff
+.DS_Store
+
 # Logs
 logs
 *.log

--- a/app/service/service-filter.js
+++ b/app/service/service-filter.js
@@ -1,4 +1,6 @@
 const serviceTokenGenerator = require('./service-token-generator')
+const {logging} = require('../logging/dm-logger')
+const logger = logging.getLogger('service-filter.js')
 
 const serviceFilter = (req, res, next) => {
   serviceTokenGenerator()
@@ -7,7 +9,9 @@ const serviceFilter = (req, res, next) => {
       next()
     })
     .catch(error => {
-      console.warn('Unsuccessful S2S authentication', error)
+      logger.warn(JSON.stringify({
+        error: 'Unsuccessful S2S authentication'
+      }))
       next({
         status: error.status || 401
       })

--- a/app/service/service-token-generator.js
+++ b/app/service/service-token-generator.js
@@ -42,7 +42,8 @@ const serviceTokenGenerator = () => {
           errorMessage: 'Non 200 status received from IDAM when getting service token.',
           statusText: error.statusText,
           status: error.status,
-          url: error.url
+          url: error.url,
+          stackTrace: error.stack
         }))
         throw error
       })

--- a/app/service/service-token-generator.js
+++ b/app/service/service-token-generator.js
@@ -8,6 +8,9 @@ const idamS2SUrl = config.get('idam.s2s_url')
 const serviceName = config.get('idam.service_name')
 const secret = config.get('idam.service_key')
 
+const {logging} = require('../logging/dm-logger')
+const logger = logging.getLogger('service-token-generator.js')
+
 const cache = {}
 
 const serviceTokenGenerator = () => {
@@ -33,6 +36,15 @@ const serviceTokenGenerator = () => {
         }
 
         return token
+      })
+      .catch(error => {
+        logger.warn(JSON.stringify({
+          errorMessage: 'Non 200 status received from IDAM when getting service token.',
+          statusText: error.statusText,
+          status: error.status,
+          url: error.url
+        }))
+        throw error
       })
   }
 }

--- a/app/user/auth-checker-user-only-filter.js
+++ b/app/user/auth-checker-user-only-filter.js
@@ -1,4 +1,6 @@
 const userRequestAuthorizer = require('./user-request-authorizer')
+const {logging} = require('../logging/dm-logger')
+const logger = logging.getLogger('auth-checker-user-only-filter.js')
 
 const authCheckerUserOnlyFilter = (req, res, next) => {
   if (req.originalUrl.startsWith('/swagger-ui.html') ||
@@ -20,8 +22,9 @@ const authCheckerUserOnlyFilter = (req, res, next) => {
       })
       .then(() => next())
       .catch(error => {
-        console.warn('Unsuccessful user authentication', error)
-        error.status = error.status || 401
+        logger.warn('Unsuccessful user authentication')
+        // Just return 401 as idam returns 400 for bad token.
+        error.status = 401
         next(error)
       })
   }

--- a/app/user/user-resolver.js
+++ b/app/user/user-resolver.js
@@ -1,6 +1,9 @@
 const config = require('config')
 const fetch = require('../util/fetch')
 
+const {logging} = require('../logging/dm-logger')
+const logger = logging.getLogger('user-resolver.js')
+
 const getTokenDetails = (jwt) => {
   const bearerJwt = jwt.startsWith('Bearer ') ? jwt : 'Bearer ' + jwt
 
@@ -8,8 +11,16 @@ const getTokenDetails = (jwt) => {
     headers: {
       'Authorization': bearerJwt
     }
-  })
-    .then(res => res.json())
+  }).then(res => res.json())
+    .catch(error => {
+      logger.warn(JSON.stringify({
+        errorMessage: 'Non 200 status received from IDAM when authenticating user. Is your token valid?',
+        statusText: error.statusText,
+        status: error.status,
+        url: error.url
+      }))
+      throw error
+    })
 }
 
 exports.getTokenDetails = getTokenDetails

--- a/app/user/user-resolver.js
+++ b/app/user/user-resolver.js
@@ -17,7 +17,8 @@ const getTokenDetails = (jwt) => {
         errorMessage: 'Non 200 status received from IDAM when authenticating user. Is your token valid?',
         statusText: error.statusText,
         status: error.status,
-        url: error.url
+        url: error.url,
+        stackTrace: error.stack
       }))
       throw error
     })

--- a/spec/service/service-filter.spec.js
+++ b/spec/service/service-filter.spec.js
@@ -5,24 +5,36 @@ const expect = chai.expect
 const sinonChai = require('sinon-chai')
 chai.use(sinonChai)
 
-describe('ServiceTokenGenerator', () => {
-  let fetch
-
-  let serviceTokenGenerator
+describe('ServiceFilter', () => {
+  let serviceFilter,
+    serviceTokenGenerator,
+    req,
+    res
 
   beforeEach(() => {
-    fetch = sinon.stub()
+    req = {
+      headers: {}
+    }
+    res = {}
 
-    serviceTokenGenerator = proxyquire('../../app/service/service-token-generator', {
-      '../util/fetch': fetch
+    serviceTokenGenerator = sinon.stub()
+
+    serviceFilter = proxyquire('../../app/service/service-filter', {
+      './service-token-generator': serviceTokenGenerator
     })
   })
 
-  it('should generate a token', () => {
-    const encodedToken = 'eyJhbGciOiJIUzI1NiJ9.eyJleHAiOiIxMjM0NTY3ODkwIn0.hv-j-ab0bWQWoLgKp7Avq3GAHbQ54qNDM63FkgQOmaM'
-    fetch.returns(Promise.resolve({text: () => encodedToken}))
-    serviceTokenGenerator()
-      .then(token => expect(token).to.equal(encodedToken))
-      .catch(err => console.log(err))
+  it('add the service token as a header', () => {
+    serviceTokenGenerator.returns(Promise.resolve('token'))
+    serviceFilter(req, res, () => {
+      expect(req.headers.ServiceAuthorization = 'token')
+    })
+  })
+
+  it('add error status if problems generating token', () => {
+    serviceTokenGenerator.returns(Promise.reject({status: 403})) // eslint-disable-line prefer-promise-reject-errors
+    serviceFilter(req, res, (err) => {
+      expect(err.status = 403)
+    })
   })
 })

--- a/spec/service/service-token-generator.spec.js
+++ b/spec/service/service-token-generator.spec.js
@@ -27,12 +27,11 @@ describe('ServiceTokenGenerator', () => {
   })
 
   it('should log error', () => {
-    const encodedToken = 'eyJhbGciOiJIUzI1NiJ9.eyJleHAiOiIxMjM0NTY3ODkwIn0.hv-j-ab0bWQWoLgKp7Avq3GAHbQ54qNDM63FkgQOmaM'
-    fetch.returns(Promise.reject({
-          statusText: 'Bad request',
-          status: 400,
-          url: 'localhost:idam'
-      }))
-    serviceTokenGenerator();
+    fetch.returns(Promise.reject(new Error({
+      statusText: 'Bad request',
+      status: 400,
+      url: 'localhost:idam'
+    })))
+    serviceTokenGenerator()
   })
 })

--- a/spec/service/service-token-generator.spec.js
+++ b/spec/service/service-token-generator.spec.js
@@ -5,36 +5,34 @@ const expect = chai.expect
 const sinonChai = require('sinon-chai')
 chai.use(sinonChai)
 
-describe('ServiceFilter', () => {
-  let serviceFilter,
-    serviceTokenGenerator,
-    req,
-    res
+describe('ServiceTokenGenerator', () => {
+  let fetch
+
+  let serviceTokenGenerator
 
   beforeEach(() => {
-    req = {
-      headers: {}
-    }
-    res = {}
+    fetch = sinon.stub()
 
-    serviceTokenGenerator = sinon.stub()
-
-    serviceFilter = proxyquire('../../app/service/service-filter', {
-      './service-token-generator': serviceTokenGenerator
+    serviceTokenGenerator = proxyquire('../../app/service/service-token-generator', {
+      '../util/fetch': fetch
     })
   })
 
-  it('add the service token as a header', () => {
-    serviceTokenGenerator.returns(Promise.resolve('token'))
-    serviceFilter(req, res, () => {
-      expect(req.headers.ServiceAuthorization = 'token')
-    })
+  it('should generate a token', () => {
+    const encodedToken = 'eyJhbGciOiJIUzI1NiJ9.eyJleHAiOiIxMjM0NTY3ODkwIn0.hv-j-ab0bWQWoLgKp7Avq3GAHbQ54qNDM63FkgQOmaM'
+    fetch.returns(Promise.resolve({text: () => encodedToken}))
+    serviceTokenGenerator()
+      .then(token => expect(token).to.equal(encodedToken))
+      .catch(err => console.log(err))
   })
 
-  it('add error status if problems generating token', () => {
-    serviceTokenGenerator.returns(Promise.reject({status: 403})) // eslint-disable-line prefer-promise-reject-errors
-    serviceFilter(req, res, (err) => {
-      expect(err.status = 403)
-    })
+  it('should log error', () => {
+    const encodedToken = 'eyJhbGciOiJIUzI1NiJ9.eyJleHAiOiIxMjM0NTY3ODkwIn0.hv-j-ab0bWQWoLgKp7Avq3GAHbQ54qNDM63FkgQOmaM'
+    fetch.returns(Promise.reject({
+          statusText: 'Bad request',
+          status: 400,
+          url: 'localhost:idam'
+      }))
+    serviceTokenGenerator();
   })
 })

--- a/spec/user/auth-checker-user-only-filter.spec.js
+++ b/spec/user/auth-checker-user-only-filter.spec.js
@@ -1,0 +1,47 @@
+const proxyquire = require('proxyquire')
+const chai = require('chai')
+const sinon = require('sinon')
+const expect = chai.expect
+const sinonChai = require('sinon-chai')
+chai.use(sinonChai)
+
+describe('User Resolver', () => {
+  let filter,
+    userRequestAuthorizer
+
+  beforeEach(() => {
+      userRequestAuthorizer = {
+          authorise: sinon.stub()
+      }
+
+      filter = proxyquire('../../app/user/auth-checker-user-only-filter', {
+      './user-request-authorizer': userRequestAuthorizer
+    })
+  })
+
+  it('should add user to req', (done) => {
+      const req = {originalUrl: '/documents'}
+      const res = {}
+      const next = () => {
+        expect(req.authentication.user).to.equal('12345')
+          done()
+      }
+
+      userRequestAuthorizer.authorise.returns(Promise.resolve('12345'))
+
+    filter(req, res, next)
+  })
+
+  it('should add 401 status if authentication fails', (done) => {
+      const req = {originalUrl: '/documents'}
+      const res = {}
+      const next = (error) => {
+        expect(error.status).to.equal(401)
+          done()
+      }
+
+      userRequestAuthorizer.authorise.returns(Promise.reject(new Error()))
+
+    filter(req, res, next)
+  })
+})

--- a/spec/user/auth-checker-user-only-filter.spec.js
+++ b/spec/user/auth-checker-user-only-filter.spec.js
@@ -5,42 +5,42 @@ const expect = chai.expect
 const sinonChai = require('sinon-chai')
 chai.use(sinonChai)
 
-describe('User Resolver', () => {
+describe('Auth Checker User Only Filter', () => {
   let filter,
     userRequestAuthorizer
 
   beforeEach(() => {
-      userRequestAuthorizer = {
-          authorise: sinon.stub()
-      }
+    userRequestAuthorizer = {
+      authorise: sinon.stub()
+    }
 
-      filter = proxyquire('../../app/user/auth-checker-user-only-filter', {
+    filter = proxyquire('../../app/user/auth-checker-user-only-filter', {
       './user-request-authorizer': userRequestAuthorizer
     })
   })
 
   it('should add user to req', (done) => {
-      const req = {originalUrl: '/documents'}
-      const res = {}
-      const next = () => {
-        expect(req.authentication.user).to.equal('12345')
-          done()
-      }
+    const req = {originalUrl: '/documents'}
+    const res = {}
+    const next = () => {
+      expect(req.authentication.user).to.equal('12345')
+      done()
+    }
 
-      userRequestAuthorizer.authorise.returns(Promise.resolve('12345'))
+    userRequestAuthorizer.authorise.returns(Promise.resolve('12345'))
 
     filter(req, res, next)
   })
 
   it('should add 401 status if authentication fails', (done) => {
-      const req = {originalUrl: '/documents'}
-      const res = {}
-      const next = (error) => {
-        expect(error.status).to.equal(401)
-          done()
-      }
+    const req = {originalUrl: '/documents'}
+    const res = {}
+    const next = (error) => {
+      expect(error.status).to.equal(401)
+      done()
+    }
 
-      userRequestAuthorizer.authorise.returns(Promise.reject(new Error()))
+    userRequestAuthorizer.authorise.returns(Promise.reject(new Error()))
 
     filter(req, res, next)
   })

--- a/spec/user/user-resolver.spec.js
+++ b/spec/user/user-resolver.spec.js
@@ -30,4 +30,15 @@ describe('User Resolver', () => {
       })
       .catch(err => console.log(err))
   })
+
+  it('should log error', () => {
+    fetch.returns(Promise.resolve(new Error({
+      statusText: 'Bad request',
+      status: 400,
+      url: 'localhost:idam'
+    })))
+
+    userResolver.getTokenDetails('token')
+      .catch(err => console.log(err))
+  })
 })


### PR DESCRIPTION
CMC have been seeing random 400 errors when calling DM. I tracked the errors down in the logs and they're coming from idam. Idam seems to return 400 if the user token is invalid. 

The logs are less than clear though as they were using `console.warn` which splits the error across multiple log entries in Kibana. I've updated them to use the hmcts logging library so they appear on all one line in Kibana. Also I've put the logging statement right at the call to IDAM so it's obvious that that is where the issue is coming from.