### PR TITLE
Re-adding error message logging

### DIFF
--- a/app/user/auth-checker-user-only-filter.js
+++ b/app/user/auth-checker-user-only-filter.js
@@ -22,9 +22,10 @@ const authCheckerUserOnlyFilter = (req, res, next) => {
       })
       .then(() => next())
       .catch(error => {
-        logger.warn('Unsuccessful user authentication')
+        let logEntry = (error.error ? JSON.stringify(error) : 'Unsuccessful user authentication')
+        logger.warn(logEntry)
         // Just return 401 as idam returns 400 for bad token.
-        error.status = 401
+        error.status = error.status && error.status !== 400 ? error.status : 401
         next(error)
       })
   }


### PR DESCRIPTION
In my last commit I changed some error logging in `auth-checker-user-only-filter.js`. I didn't realise that we got some information about an error from the `user-request-authorizer.js` as well so we ended up losing that. I've reinstated that logging.