### PR TITLE
Add user-id as header to request

### DIFF
--- a/app/user/auth-checker-user-only-filter.js
+++ b/app/user/auth-checker-user-only-filter.js
@@ -19,6 +19,7 @@ const authCheckerUserOnlyFilter = (req, res, next) => {
       .then(user => {
         req.authentication.user = user
         req.headers['user-id'] = user.id
+        req.headers['user-roles'] = user.roles.join(',')
         return null
       })
       .then(() => next())

--- a/app/user/auth-checker-user-only-filter.js
+++ b/app/user/auth-checker-user-only-filter.js
@@ -18,6 +18,7 @@ const authCheckerUserOnlyFilter = (req, res, next) => {
       .authorise(req)
       .then(user => {
         req.authentication.user = user
+        req.headers['user-id'] = user.id
         return null
       })
       .then(() => next())

--- a/app/user/user-request-authorizer.js
+++ b/app/user/user-request-authorizer.js
@@ -34,6 +34,9 @@ const authorise = (request) => {
   return userResolver
     .getTokenDetails(bearerToken)
     .then(tokenDetails => {
+      if (!tokenDetails.id) {
+        throw new Error('No user ID returned from IDAM')
+      }
       user = tokenDetails
       return null
     })

--- a/spec/user/auth-checker-user-only-filter.spec.js
+++ b/spec/user/auth-checker-user-only-filter.spec.js
@@ -22,7 +22,7 @@ describe('Auth Checker User Only Filter', () => {
   it('should add user to req', (done) => {
     const req = {originalUrl: '/documents', headers: {}}
     const res = {}
-    const user = {id: '12345'}
+    const user = {id: '12345', roles: []}
     const next = () => {
       expect(req.authentication.user).to.equal(user)
       done()
@@ -36,9 +36,23 @@ describe('Auth Checker User Only Filter', () => {
   it('should add userId to req header', (done) => {
     const req = {originalUrl: '/documents', headers: {}}
     const res = {}
-    const user = {id: '12345'}
+    const user = {id: '12345', roles: []}
     const next = () => {
       expect(req.headers['user-id']).to.equal(user.id)
+      done()
+    }
+
+    userRequestAuthorizer.authorise.returns(Promise.resolve(user))
+
+    filter(req, res, next)
+  })
+
+  it('should add roles to req header', (done) => {
+    const req = {originalUrl: '/documents', headers: {}}
+    const res = {}
+    const user = {id: '12345', roles: ['case-worker', 'citizen']}
+    const next = () => {
+      expect(req.headers['user-roles']).to.equal('case-worker,citizen')
       done()
     }
 

--- a/spec/user/auth-checker-user-only-filter.spec.js
+++ b/spec/user/auth-checker-user-only-filter.spec.js
@@ -20,14 +20,29 @@ describe('Auth Checker User Only Filter', () => {
   })
 
   it('should add user to req', (done) => {
-    const req = {originalUrl: '/documents'}
+    const req = {originalUrl: '/documents', headers: {}}
     const res = {}
+    const user = {id: '12345'}
     const next = () => {
-      expect(req.authentication.user).to.equal('12345')
+      expect(req.authentication.user).to.equal(user)
       done()
     }
 
-    userRequestAuthorizer.authorise.returns(Promise.resolve('12345'))
+    userRequestAuthorizer.authorise.returns(Promise.resolve(user))
+
+    filter(req, res, next)
+  })
+
+  it('should add userId to req header', (done) => {
+    const req = {originalUrl: '/documents', headers: {}}
+    const res = {}
+    const user = {id: '12345'}
+    const next = () => {
+      expect(req.headers['user-id']).to.equal(user.id)
+      done()
+    }
+
+    userRequestAuthorizer.authorise.returns(Promise.resolve(user))
 
     filter(req, res, next)
   })

--- a/spec/user/user-request-authorizer.spec.js
+++ b/spec/user/user-request-authorizer.spec.js
@@ -66,6 +66,17 @@ describe('UserRequestAuthorizer', () => {
         })
     })
 
+    it('should exception if id is missing', done => {
+      userResolver.getTokenDetails.returns(Promise.resolve({}))
+
+      userRequestAuthorizer.authorise(request)
+        .then(() => fail('Promise should have been rejected'))
+        .catch(error => {
+          expect(error.message).to.contain('ID')
+          done()
+        })
+    })
+
     xit('should reject when roles do not match', done => {
       authorizedRolesExtractor.extract.returns(['no-match'])
 


### PR DESCRIPTION
Add the user-id from received from idam to the request header that is then passed to the service layer. This allows the service layer to the authenticate with just the service token and not require a logged in user.