### PR TITLE
Return json error if accept is not text/html

### DIFF
--- a/app/router/dm-error.js
+++ b/app/router/dm-error.js
@@ -1,3 +1,8 @@
+function formatJsonError (res, err) {
+  res.contentType('application/json')
+  res.json(err)
+}
+
 const dmErrorHandle = (err, req, res, next) => {
   // set locals, only providing error in development
   res.locals.asset_path = '/public/'
@@ -12,8 +17,11 @@ const dmErrorHandle = (err, req, res, next) => {
     'text/html': function () {
       res.render('errors/error', err)
     },
-    default: function () {
-      res.json(err)
+    '*/*': function () {
+      formatJsonError(res, err)
+    },
+    'default': function () {
+      formatJsonError(res, err)
     }
   })
 }

--- a/spec/router/dm-error.spec.js
+++ b/spec/router/dm-error.spec.js
@@ -8,7 +8,7 @@ chai.use(sinonChai)
 const errorHandler = require('../../app/router/dm-error')
 
 describe('dm error', () => {
-  let err, req, res, format
+  let err, req, res, format, contentType
 
   beforeEach(() => {
     err = {}
@@ -19,6 +19,9 @@ describe('dm error', () => {
       format: toFormat => {
         format = toFormat
         return null
+      },
+      contentType: aContentType => {
+        contentType = aContentType
       },
       locals: {}
     }
@@ -65,6 +68,24 @@ describe('dm error', () => {
 
     describe('when the content type is not text/html', () => {
       beforeEach(() => {
+        format['*/*']()
+      })
+
+      it('should call json with the error', () => {
+        res.json.should.have.been.calledWith(err)
+      })
+
+      it('should not call render', () => {
+        res.render.should.not.have.been.called
+      })
+
+      it('should have a content tpe of application/json', () => {
+        expect(contentType).to.equal('application/json')
+      })
+    })
+
+    describe('when the content type is not text/html', () => {
+      beforeEach(() => {
         format.default()
       })
 
@@ -74,6 +95,10 @@ describe('dm error', () => {
 
       it('should not call render', () => {
         res.render.should.not.have.been.called
+      })
+
+      it('should have a content type of application/json', () => {
+        expect(contentType).to.equal('application/json')
       })
     })
   })


### PR DESCRIPTION
Resolves an issue where services were receiving errors in html when calling the service without a set `accept` header.
