### PR TITLE
Fix issue with 'circular object' written as JSON

### DIFF
--- a/app/router/dm-error.js
+++ b/app/router/dm-error.js
@@ -1,8 +1,8 @@
 function formatJsonError (res, err) {
   res.contentType('application/json')
   res.json({
-      statusText: err.statusText,
-      status: err.status
+    statusText: err.statusText,
+    status: err.status
   })
 }
 

--- a/app/router/dm-error.js
+++ b/app/router/dm-error.js
@@ -2,6 +2,7 @@ function formatJsonError (res, err) {
   res.contentType('application/json')
   res.json({
     statusText: err.statusText,
+    error: err.error,
     status: err.status
   })
 }
@@ -13,7 +14,7 @@ const dmErrorHandle = (err, req, res, next) => {
   // render the error page
   const status = isNaN(err.status) ? 500 : err.status
   if (status >= 500) {
-    err.error = 'Internal Server Error'
+    err.statusText = err.error = 'Internal Server Error'
   }
   res.status(status)
   res.format({

--- a/app/router/dm-error.js
+++ b/app/router/dm-error.js
@@ -1,6 +1,9 @@
 function formatJsonError (res, err) {
   res.contentType('application/json')
-  res.json(err)
+  res.json({
+      statusText: err.statusText,
+      status: err.status
+  })
 }
 
 const dmErrorHandle = (err, req, res, next) => {

--- a/spec/router/dm-error.spec.js
+++ b/spec/router/dm-error.spec.js
@@ -49,7 +49,7 @@ describe('dm error', () => {
     })
 
     it('should set the error to Internal Server Error', () => {
-      expect(err.error).to.equal('Internal Server Error')
+      expect(err.statusText).to.equal('Internal Server Error')
     })
 
     describe('when the content type is text/html', () => {


### PR DESCRIPTION
Noticed a problem in some situations where we were getting an HTML error message. It turned out it was trying to render JSON but was failing because the object was had circular references which couldn't be serialised.